### PR TITLE
Use new keycloak instance

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -7,3 +7,17 @@ data "aws_ssm_parameter" "management_account" {
 }
 
 data "aws_caller_identity" "current" {}
+
+resource "random_password" "password" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "keycloak_password" {
+  length  = 16
+  special = false
+}
+
+resource "random_uuid" "client_secret" {}
+resource "random_uuid" "backend_checks_client_secret" {}
+resource "random_uuid" "reporting_client_secret" {}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -29,4 +29,17 @@ locals {
     "download_files" = 180,
     "file_format"    = 900
   }
+  auth_url = "https://auth.tdr-sandbox.nationalarchives.gov.uk/auth"
+
+  keycloak_backend_checks_secret_name     = "/${local.environment}/keycloak/backend_checks_client/secret"
+  keycloak_tdr_client_secret_name         = "/${local.environment}/keycloak/client/secret"
+  keycloak_user_password_name             = "/${local.environment}/keycloak/password"
+  keycloak_admin_password_name            = "/${local.environment}/keycloak/admin/password"
+  keycloak_admin_user_name                = "/${local.environment}/keycloak/admin/user"
+  keycloak_realm_admin_client_secret_name = "/${local.environment}/keycloak/realm_admin_client/secret"
+  keycloak_configuration_properties_name  = "/${local.environment}/keycloak/configuration_properties"
+  keycloak_user_admin_client_secret_name  = "/${local.environment}/keycloak/user_admin_client/secret"
+  keycloak_govuk_notify_api_key_name      = "/${local.environment}/keycloak/govuk_notify/api_key"
+  keycloak_govuk_notify_template_id_name  = "/${local.environment}/keycloak/govuk_notify/template_id"
+  keycloak_reporting_client_secret_name   = "/${local.environment}/keycloak/reporting_client/secret"
 }

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -451,7 +451,7 @@ module "keycloak_database_security_group" {
   common_tags = local.common_tags
   ingress_security_group_rules = [
     { port = 5432, security_group_id = module.keycloak_ecs_security_group.security_group_id, description = "Allow Postgres port from the ECS task" },
-    { port = 5432, security_group_id = module.create_keycloak_db_users_lambda_new.create_keycloak_user_lambda_security_group_new[0], description = "Allow Postgres port from the create user lambda" }
+    { port = 5432, security_group_id = module.create_keycloak_db_users_lambda_new.create_keycloak_user_lambda_security_group[0], description = "Allow Postgres port from the create user lambda" }
   ]
   egress_security_group_rules = [{ port = 5432, security_group_id = module.keycloak_ecs_security_group.security_group_id, description = "Allow Postgres port from the ECS task", protocol = "-1" }]
 }
@@ -531,7 +531,7 @@ module "create_keycloak_db_users_lambda_new" {
   source                              = "./tdr-terraform-modules/lambda"
   project                             = var.project
   common_tags                         = local.common_tags
-  lambda_create_keycloak_db_users_new = true
+  lambda_create_keycloak_db_users     = true
   vpc_id                              = module.shared_vpc.vpc_id
   private_subnet_ids                  = module.shared_vpc.private_subnets
   db_admin_user                       = module.keycloak_database.db_username

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -446,7 +446,7 @@ module "keycloak_alb_security_group" {
 module "keycloak_database_security_group" {
   source      = "./tdr-terraform-modules/security_group"
   description = "Controls access to the keycloak database"
-  name        = "keycloak-database-security-group-new-${local.environment}"
+  name        = "keycloak-database-security-group-${local.environment}"
   vpc_id      = module.shared_vpc.vpc_id
   common_tags = local.common_tags
   ingress_security_group_rules = [
@@ -459,7 +459,7 @@ module "keycloak_database_security_group" {
 module "tdr_keycloak" {
   source               = "./tdr-terraform-modules/generic_ecs"
   alb_target_group_arn = module.keycloak_tdr_alb.alb_target_group_arn
-  cluster_name         = "keycloak_new_${local.environment}"
+  cluster_name         = "keycloak_${local.environment}"
   common_tags          = local.common_tags
   container_definition = templatefile("./tdr-terraform-environments/templates/ecs_tasks/keycloak.json.tpl", {
     app_image                         = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/auth-server:${local.environment}"

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -22,7 +22,7 @@ module "consignment_api" {
   vpc_id                         = module.shared_vpc.vpc_id
   region                         = local.region
   db_migration_sg                = module.database_migrations.db_migration_security_group
-  auth_url                       = module.keycloak.auth_url
+  auth_url                       = local.auth_url
   kms_key_id                     = module.encryption_key.kms_key_arn
   frontend_url                   = "https://tdr-sandbox.nationalarchives.gov.uk"
   dns_zone_name_trimmed          = local.dns_zone_name_trimmed
@@ -45,47 +45,6 @@ module "consignment_api_alb" {
   public_subnets        = module.shared_vpc.public_subnets
   vpc_id                = module.shared_vpc.vpc_id
   common_tags           = local.common_tags
-}
-
-module "keycloak" {
-  app_name                      = "keycloak"
-  source                        = "./tdr-terraform-environments/modules/keycloak"
-  alb_dns_name                  = module.keycloak_alb.alb_dns_name
-  alb_target_group_arn          = module.keycloak_alb.alb_target_group_arn
-  alb_zone_id                   = module.keycloak_alb.alb_zone_id
-  dns_zone_id                   = local.dns_zone_id
-  dns_zone_name_trimmed         = local.dns_zone_name_trimmed
-  environment                   = local.environment
-  environment_full_name         = local.environment_full_name
-  common_tags                   = local.common_tags
-  database_availability_zones   = local.database_availability_zones
-  az_count                      = 2
-  region                        = local.region
-  frontend_url                  = ""
-  kms_key_id                    = module.encryption_key.kms_key_arn
-  create_user_security_group_id = module.create_keycloak_db_users_lambda.create_keycloak_user_lambda_security_group
-  notification_sns_topic        = module.notifications_topic.sns_arn
-  kms_key_arn                   = module.encryption_key.kms_key_arn
-}
-
-module "keycloak_alb" {
-  source                = "./tdr-terraform-modules/alb"
-  project               = var.project
-  function              = "keycloak"
-  environment           = local.environment
-  alb_log_bucket        = module.alb_logs_s3.s3_bucket_id
-  alb_security_group_id = module.keycloak.alb_security_group_id
-  alb_target_group_port = 8080
-  alb_target_type       = "ip"
-  certificate_arn       = module.keycloak_certificate.certificate_arn
-  health_check_matcher  = "200,303"
-  health_check_path     = ""
-  http_listener         = false
-  public_subnets        = module.keycloak.public_subnets
-  vpc_id                = module.keycloak.vpc_id
-  common_tags           = local.common_tags
-  own_host_header_only  = true
-  host                  = module.keycloak.auth_host
 }
 
 module "keycloak_certificate" {
@@ -114,21 +73,6 @@ module "encryption_key" {
   key_policy  = "message_system_access"
   environment = local.environment
   common_tags = local.common_tags
-}
-
-module "create_keycloak_db_users_lambda" {
-  source                           = "./tdr-terraform-modules/lambda"
-  project                          = var.project
-  common_tags                      = local.common_tags
-  lambda_create_keycloak_db_users  = true
-  vpc_id                           = module.keycloak.vpc_id
-  private_subnet_ids               = module.keycloak.private_subnets
-  db_admin_user                    = module.keycloak.db_username
-  db_admin_password                = module.keycloak.db_password
-  db_url                           = module.keycloak.db_url
-  kms_key_arn                      = module.encryption_key.kms_key_arn
-  keycloak_password                = module.keycloak.keycloak_user_password
-  keycloak_database_security_group = module.keycloak.database_security_group
 }
 
 module "notifications_topic" {
@@ -263,7 +207,7 @@ module "download_files_lambda" {
   backend_checks_efs_access_point        = module.backend_checks_efs.access_point
   vpc_id                                 = module.shared_vpc.vpc_id
   use_efs                                = true
-  auth_url                               = module.keycloak.auth_url
+  auth_url                               = local.auth_url
   api_url                                = module.consignment_api.api_url
   backend_checks_efs_root_directory_path = module.backend_checks_efs.root_directory_path
   private_subnet_ids                     = module.backend_checks_efs.private_subnets
@@ -385,7 +329,7 @@ module "api_update_lambda" {
   common_tags                           = local.common_tags
   lambda_api_update                     = true
   timeout_seconds                       = local.file_check_lambda_timeouts_in_seconds["api_update"]
-  auth_url                              = module.keycloak.auth_url
+  auth_url                              = local.auth_url
   api_url                               = module.consignment_api.api_url
   keycloak_backend_checks_client_secret = module.keycloak.backend_checks_client_secret
   kms_key_arn                           = module.encryption_key.kms_key_arn
@@ -418,4 +362,194 @@ module "ecr_file_format_build_repository" {
   policy_name      = "sandbox_performance_check_policy"
   policy_variables = { management_account = data.aws_ssm_parameter.management_account.value, sandbox_account = data.aws_caller_identity.current.account_id }
   common_tags      = local.common_tags
+}
+
+module "keycloak_cloudwatch" {
+  source      = "./tdr-terraform-modules/cloudwatch_logs"
+  common_tags = local.common_tags
+  name        = "/ecs/keycloak-auth-${local.environment}"
+}
+
+module "keycloak_ecs_execution_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "KeycloakECSExecutionPolicy${title(local.environment)}"
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_execution_policy.json.tpl", { cloudwatch_log_group = module.keycloak_cloudwatch.log_group_arn, ecr_account_number = local.ecr_account_number })
+}
+
+module "keycloak_ecs_task_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "KeycloakECSTaskPolicy${title(local.environment)}"
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/keycloak_ecs_task_role_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id, environment = local.environment, kms_arn = module.encryption_key.kms_key_arn })
+}
+
+module "keycloak_execution_role" {
+  source             = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
+  common_tags        = local.common_tags
+  name               = "KeycloakECSExecutionRole${title(local.environment)}"
+  policy_attachments = {
+    ssm_policy       = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess",
+    execution_policy = module.keycloak_ecs_execution_policy.policy_arn
+  }
+}
+
+module "keycloak_task_role" {
+  source             = "./tdr-terraform-modules/iam_role"
+  assume_role_policy = templatefile("./tdr-terraform-modules/ecs/templates/ecs_assume_role_policy.json.tpl", {})
+  common_tags        = local.common_tags
+  name               = "KeycloakECSTaskRole${title(local.environment)}"
+  policy_attachments = { task_policy = module.keycloak_ecs_task_policy.policy_arn }
+}
+
+module "keycloak_ssm_parameters" {
+  source      = "./tdr-terraform-modules/ssm_parameter"
+  common_tags = local.common_tags
+  random_parameters = [
+    { name = local.keycloak_backend_checks_secret_name, description = "The Keycloak backend checks secret", value = random_uuid.backend_checks_client_secret.result, type = "SecureString" },
+    { name = local.keycloak_tdr_client_secret_name, description = "The Keycloak tdr client secret", value = random_uuid.client_secret.result, type = "SecureString" },
+    { name = local.keycloak_user_password_name, description = "The Keycloak user password", value = random_password.keycloak_password.result, type = "SecureString" },
+    { name = local.keycloak_admin_password_name, description = "The Keycloak admin password", value = random_password.password.result, type = "SecureString" },
+    { name = local.keycloak_govuk_notify_api_key_name, description = "The GovUK Notify API key", value = "to_be_manually_added", type = "SecureString" },
+    { name = local.keycloak_govuk_notify_template_id_name, description = "The GovUK Notify Template ID", value = "to_be_manually_added", type = "SecureString" },
+    { name = local.keycloak_admin_user_name, description = "The Keycloak admin user", value = "tdr-keycloak-admin-${local.environment}", type = "SecureString" },
+    { name = local.keycloak_configuration_properties_name, description = "The Keycloak configuration properties file ", value = "${local.environment}_properties.json", type = "SecureString" },
+    { name = local.keycloak_user_admin_client_secret_name, description = "The Keycloak user admin secret", value = random_uuid.backend_checks_client_secret.result, type = "SecureString" },
+    { name = local.keycloak_reporting_client_secret_name, description = "The Keycloak reporting client secret", value = random_uuid.reporting_client_secret.result, type = "SecureString" },
+    { name = local.keycloak_realm_admin_client_secret_name, description = "The Keycloak realm admin secret", value = random_uuid.backend_checks_client_secret.result, type = "SecureString" }
+  ]
+}
+
+module "keycloak_ecs_security_group" {
+  source      = "./tdr-terraform-modules/security_group"
+  description = "Controls access within our network for the Keycloak ECS Task"
+  name        = "tdr-keycloak-ecs-security-group-new"
+  vpc_id      = module.shared_vpc.vpc_id
+  common_tags = local.common_tags
+  ingress_security_group_rules = [
+    { port = 8080, security_group_id = module.keycloak_alb_security_group.security_group_id, description = "Allow the load balancer to access the task" }
+  ]
+  egress_cidr_rules = [{ port = 0, cidr_blocks = ["0.0.0.0/0"], description = "Allow outbound access on all ports", protocol = "-1" }]
+}
+
+module "keycloak_alb_security_group" {
+  source      = "./tdr-terraform-modules/security_group"
+  description = "Controls access to the keycloak load balancer"
+  name        = "keycloak-load-balancer-security-group-new"
+  vpc_id      = module.shared_vpc.vpc_id
+  common_tags = local.common_tags
+  ingress_cidr_rules = [
+    { port = 443, cidr_blocks = ["0.0.0.0/0"], description = "Allow all IPs over HTTPS" }
+  ]
+  egress_cidr_rules = [{ port = 0, cidr_blocks = ["0.0.0.0/0"], description = "Allow outbound access on all ports", protocol = "-1" }]
+}
+
+module "keycloak_database_security_group" {
+  source      = "./tdr-terraform-modules/security_group"
+  description = "Controls access to the keycloak database"
+  name        = "keycloak-database-security-group-new-${local.environment}"
+  vpc_id      = module.shared_vpc.vpc_id
+  common_tags = local.common_tags
+  ingress_security_group_rules = [
+    { port = 5432, security_group_id = module.keycloak_ecs_security_group.security_group_id, description = "Allow Postgres port from the ECS task" },
+    { port = 5432, security_group_id = module.create_keycloak_db_users_lambda_new.create_keycloak_user_lambda_security_group_new[0], description = "Allow Postgres port from the create user lambda" }
+  ]
+  egress_security_group_rules = [{ port = 5432, security_group_id = module.keycloak_ecs_security_group.security_group_id, description = "Allow Postgres port from the ECS task", protocol = "-1" }]
+}
+
+module "tdr_keycloak" {
+  source               = "./tdr-terraform-modules/generic_ecs"
+  alb_target_group_arn = module.keycloak_tdr_alb.alb_target_group_arn
+  cluster_name         = "keycloak_new_${local.environment}"
+  common_tags          = local.common_tags
+  container_definition = templatefile("${path.module}/templates/ecs_tasks/keycloak.json.tpl", {
+    app_image                         = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-2.amazonaws.com/auth-server:${local.environment}"
+    app_port                          = 8080
+    app_environment                   = local.environment
+    aws_region                        = local.region
+    url_path                          = module.keycloak_database.db_url_parameter_name
+    username                          = "keycloak_user"
+    password_path                     = local.keycloak_user_password_name
+    admin_user_path                   = local.keycloak_admin_user_name
+    admin_password_path               = local.keycloak_admin_password_name
+    client_secret_path                = local.keycloak_tdr_client_secret_name
+    backend_checks_client_secret_path = local.keycloak_backend_checks_secret_name
+    realm_admin_client_secret_path    = local.keycloak_realm_admin_client_secret_name
+    frontend_url                      = "https://tdr-sandbox.nationalarchives.gov.uk"
+    configuration_properties_path     = local.keycloak_configuration_properties_name
+    user_admin_client_secret_path     = local.keycloak_user_admin_client_secret_name
+    govuk_notify_api_key_path         = local.keycloak_govuk_notify_api_key_name
+    govuk_notify_template_id_path     = local.keycloak_govuk_notify_template_id_name
+    reporting_client_secret_path      = local.keycloak_reporting_client_secret_name
+    sns_topic_arn                     = module.notifications_topic.sns_arn
+  })
+  container_name               = "keycloak"
+  cpu                          = 1024
+  environment                  = local.environment
+  execution_role               = module.keycloak_execution_role.role.arn
+  load_balancer_container_port = 8080
+  memory                       = 3072
+  private_subnets              = module.shared_vpc.private_subnets
+  security_groups              = [module.keycloak_ecs_security_group.security_group_id]
+  service_name                 = "keycloak_${local.environment}"
+  task_family_name             = "keycloak-${local.environment}"
+  task_role                    = module.keycloak_task_role.role.arn
+}
+
+module "keycloak_tdr_alb" {
+  source                = "./tdr-terraform-modules/alb"
+  project               = var.project
+  function              = "keycloak-new"
+  environment           = local.environment
+  alb_log_bucket        = module.alb_logs_s3.s3_bucket_id
+  alb_security_group_id = module.keycloak_alb_security_group.security_group_id
+  alb_target_group_port = 8080
+  alb_target_type       = "ip"
+  certificate_arn       = module.keycloak_certificate.certificate_arn
+  health_check_matcher  = "200,303"
+  health_check_path     = ""
+  http_listener         = false
+  public_subnets        = module.shared_vpc.public_subnets
+  vpc_id                = module.shared_vpc.vpc_id
+  common_tags           = local.common_tags
+  own_host_header_only  = true
+  host                  = "auth.${local.environment_domain}"
+}
+
+module "keycloak_database" {
+  source                      = "./tdr-terraform-modules/rds"
+  admin_username              = "keycloak_admin"
+  common_tags                 = local.common_tags
+  database_availability_zones = local.database_availability_zones
+  database_name               = "keycloak"
+  environment                 = local.environment
+  kms_key_id                  = module.encryption_key.kms_key_arn
+  private_subnets             = module.shared_vpc.private_subnets
+  security_group_ids          = [module.keycloak_database_security_group.security_group_id]
+}
+
+module "create_keycloak_db_users_lambda_new" {
+  source                              = "./tdr-terraform-modules/lambda"
+  project                             = var.project
+  common_tags                         = local.common_tags
+  lambda_create_keycloak_db_users_new = true
+  vpc_id                              = module.shared_vpc.vpc_id
+  private_subnet_ids                  = module.shared_vpc.private_subnets
+  db_admin_user                       = module.keycloak_database.db_username
+  db_admin_password                   = module.keycloak_database.db_password
+  db_url                              = module.keycloak_database.db_url
+  kms_key_arn                         = module.encryption_key.kms_key_arn
+  keycloak_password                   = module.keycloak_ssm_parameters.params[local.keycloak_user_password_name].value
+  keycloak_database_security_group    = module.keycloak_database_security_group.security_group_id
+}
+
+module "keycloak_route53" {
+  source                = "./tdr-terraform-modules/route53"
+  common_tags           = local.common_tags
+  environment_full_name = local.environment_full_name
+  project               = "tdr"
+  a_record_name         = "auth"
+  alb_dns_name          = module.keycloak_tdr_alb.alb_dns_name
+  alb_zone_id           = module.keycloak_tdr_alb.alb_zone_id
+  create_hosted_zone    = false
+  hosted_zone_id        = data.aws_route53_zone.tdr_dns_zone.id
 }


### PR DESCRIPTION
I've removed the old module and created Keycloak in the TDR VPC using terraform modules. I've updated the terraform here to use the new version.

