### PR TITLE
Get all log events and fix rate limiting errors

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/performancechecks/aws/LogUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/performancechecks/aws/LogUtils.scala
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.cloudwatchlogs.model.{DeleteLogStreamRequ
 import uk.gov.nationalarchives.performancechecks.Main.{FileCheckResults, Result}
 import uk.gov.nationalarchives.performancechecks.aws.STSUtils.assumeRoleProvider
 import uk.gov.nationalarchives.performancechecks.aws.LambdaUtils.FutureUtils
+import scala.concurrent.duration._
 
 import scala.jdk.CollectionConverters._
 import io.circe.generic.auto._
@@ -22,9 +23,20 @@ object LogUtils {
     client.getLogEvents(request).toIO
   }
 
-  private def getLogStreams(logGroupName: String) = {
-    val request = DescribeLogStreamsRequest.builder.logGroupName(logGroupName).build()
-    client.describeLogStreams(request).toIO
+  private def getLogStreams(logGroupName: String, nextToken: Option[String] = None): IO[List[LogStream]] = {
+    val request = if(nextToken.isDefined) {
+      DescribeLogStreamsRequest.builder.logGroupName(logGroupName).nextToken(nextToken.get).build
+    } else {
+      DescribeLogStreamsRequest.builder.logGroupName(logGroupName).build
+    }
+    for {
+      res <- client.describeLogStreams(request).toIO
+      streams <- if(res.nextToken== null) {
+        IO.sleep(2.seconds) >> IO(res.logStreams.asScala.toList)
+      } else {
+        IO.sleep(2.second) >> getLogStreams(logGroupName, Some(res.nextToken)).flatMap(s => IO(s ++ res.logStreams.asScala.toList))
+      }
+    } yield streams
   }
 
   def deleteExistingLogStreams(lambdas: List[String]): IO[List[Unit]] = {
@@ -32,7 +44,7 @@ object LogUtils {
       val logGroupName = s"/aws/lambda/tdr-$lambdaName-sbox"
       for {
         result <- getLogStreams(logGroupName)
-        _ <- result.logStreams.asScala.toList.map(logStream => {
+        _ <- result.map(logStream => {
           val deleteRequest = DeleteLogStreamRequest.builder
             .logGroupName(logGroupName)
             .logStreamName(logStream.logStreamName)
@@ -47,7 +59,7 @@ object LogUtils {
     val logGroupName = s"/aws/lambda/tdr-$lambdaName-sbox"
     for {
       result <- getLogStreams(logGroupName)
-      logEvents <- result.logStreams().asScala.toList.map(logStream => getLogEvents(logStream, logGroupName)).sequence
+      logEvents <- result.map(logStream => IO.sleep(200.milliseconds) >> getLogEvents(logStream, logGroupName)).sequence
     } yield {
       val messages = for {
         logEvent <- logEvents

--- a/src/main/scala/uk/gov/nationalarchives/performancechecks/aws/LogUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/performancechecks/aws/LogUtils.scala
@@ -49,17 +49,17 @@ object LogUtils {
             .logGroupName(logGroupName)
             .logStreamName(logStream.logStreamName)
             .build
-          client.deleteLogStream(deleteRequest).toIO
+          client.deleteLogStream(deleteRequest).toIO >> IO.sleep(250.milliseconds)
         }).sequence
       } yield ()
-    }).sequence
+    } >> IO.sleep(1.second)).sequence
   }
 
   def getMessages(lambdas: List[String]): IO[List[Messages]] = lambdas.map(lambdaName => {
     val logGroupName = s"/aws/lambda/tdr-$lambdaName-sbox"
     for {
       result <- getLogStreams(logGroupName)
-      logEvents <- result.map(logStream => IO.sleep(200.milliseconds) >> getLogEvents(logStream, logGroupName)).sequence
+      logEvents <- result.map(logStream => IO.sleep(250.milliseconds) >> getLogEvents(logStream, logGroupName)).sequence
     } yield {
       val messages = for {
         logEvent <- logEvents

--- a/src/main/scala/uk/gov/nationalarchives/performancechecks/html/HtmlReport.scala
+++ b/src/main/scala/uk/gov/nationalarchives/performancechecks/html/HtmlReport.scala
@@ -73,7 +73,7 @@ class HtmlReport(aggregateResults: List[AggregateResults]) {
                       )
                     ),
                     tbody(
-                      for (row <- result.results.sortBy(-_.timeTaken)) yield
+                      for (row <- result.results.sortBy(-_.timeTaken).take(10)) yield
                         tr(
                           td(row.filePath),
                           td(row.fileSize),


### PR DESCRIPTION
DescribeLogStreams will only bring back a maximum of 50 streams. For a large number of files, there may be more than this, especially for the file format lambda which produces a lot of logs.
    
We need to recursively loop around until the nextToken is blank so we're sure we've got them all. The problem with this is that we hit the rate limits for cloudfront which doesn't allow more than 5 requests a second. We can also hit this rate limit when deleting a large number of logs at the beginning of the process so I've added in some `IO.sleep` statements to try to stop this happening.
    
I've also added `take(10)` to the report so it doesn't print more than 10 records to the web page.

